### PR TITLE
Add a delay when restarting handle-queue

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject motiva/sqs-utils "0.3.0-SNAPSHOT"
+(defproject motiva/sqs-utils "0.2.3-SNAPSHOT"
   :description "Higher level SQS utilities for use in Motiva products"
   :url "https://github.com/Motiva-AI/sqs-utils"
   :license {:name "MIT License"


### PR DESCRIPTION
This loop in `handle-queue` runs off the track indefinitely if a queue listener fails to start. Then our log get dump GBs of data in minutes. This add a configurable pause between restarts.