### PR TITLE
enable message deduplication feature for send-fifo-message

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,20 @@ Send messages to a queue:
 sqs-utils.core> (doc send-message)
 -------------------------
 sqs-utils.core/send-message
-([sqs-config queue-url payload & {:keys [group-id]}])
+[sqs-config queue-url payload]
   Send a message to a standard queue.
 => nil
 sqs-utils.core> (doc send-fifo-message)
 -------------------------
 sqs-utils.core/send-fifo-message
-([sqs-config queue-url message-group-id payload])
-  Send a message to a FIFO queue. message-group-id is a tag that specifies the
-  group that this message belongs to. Messages belonging to the same group are
-  guaranteed FIFO.
+[sqs-config queue-url payload {message-group-id :message-group-id, deduplication-id :deduplication-id, :as options}]
+  Send a message to a FIFO queue.
+
+  Options:
+  message-group-id - a tag that specifies the group that this message
+  belongs to. Messages belonging to the same group
+  are guaranteed FIFO
+  deduplication-id -  token used for deduplication of sent messages
 => nil
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,10 +59,12 @@ sqs-utils.core/send-fifo-message
 [sqs-config queue-url payload {message-group-id :message-group-id, deduplication-id :deduplication-id, :as options}]
   Send a message to a FIFO queue.
 
-  Options:
+  Argments:
   message-group-id - a tag that specifies the group that this message
   belongs to. Messages belonging to the same group
   are guaranteed FIFO
+
+  Options:
   deduplication-id -  token used for deduplication of sent messages
 => nil
 ```

--- a/project.clj
+++ b/project.clj
@@ -39,8 +39,12 @@
 
                    :env {:sqs-endpoint          "http://localhost:9324"
                          :sqs-region            "us-east-2"
-                         :aws-access-key-id     "local"
-                         :aws-secret-access-key "local"}}}
+                         :standard-integration-test-queue-url ""
+                         :fifo-integration-test-queue-url     ""
+                         :aws-access-key-id          "local"
+                         :aws-secret-access-key      "local"
+                         :integration-aws-access-key ""
+                         :integration-aws-secret-key ""}}}
 
   :test-selectors {:default     (complement :integration)
                    :integration :integration

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject motiva/sqs-utils "0.2.3"
+(defproject motiva/sqs-utils "0.3.0-SNAPSHOT"
   :description "Higher level SQS utilities for use in Motiva products"
   :url "https://github.com/Motiva-AI/sqs-utils"
   :license {:name "MIT License"

--- a/src/sqs_utils/core.clj
+++ b/src/sqs_utils/core.clj
@@ -179,10 +179,12 @@
 (defn send-fifo-message
   "Send a message to a FIFO queue.
 
-   Options:
+   Arguments:
    message-group-id - a tag that specifies the group that this message
                       belongs to. Messages belonging to the same group
                       are guaranteed FIFO
+
+   Options:
    deduplication-id -  token used for deduplication of sent messages"
   [sqs-config
    queue-url

--- a/src/sqs_utils/core.clj
+++ b/src/sqs_utils/core.clj
@@ -157,12 +157,14 @@
 
 (defn send-message*
   "Send a message to a queue."
-  [sqs-config queue-url payload & {:keys [group-id]}]
+  [sqs-config queue-url payload {:keys [message-group-id
+                                        deduplication-id]}]
   (let [resp (<!! (sqs/send-message!
                     sqs-config
                     queue-url
                     (cond-> {:body payload :fink-nottle/tag :transit}
-                      group-id (assoc :message-group-id (str group-id)))))]
+                      message-group-id (assoc :message-group-id (str message-group-id))
+                      deduplication-id (assoc :message-deduplication-id (str deduplication-id)))))]
     ;; sqs/send-message! returns Exceptions into the channel
     (if (instance? Exception resp)
       (throw resp)
@@ -172,14 +174,23 @@
   "Send a message to a standard queue."
   [sqs-config queue-url payload]
   ;; Note that standard queues don't support message-group-id
-  (send-message* sqs-config queue-url payload))
+  (send-message* sqs-config queue-url payload {}))
 
 (defn send-fifo-message
-  "Send a message to a FIFO queue. message-group-id is a tag that specifies the
-  group that this message belongs to. Messages belonging to the same group are
-  guaranteed FIFO."
-  [sqs-config queue-url message-group-id payload]
-  (send-message* sqs-config queue-url payload :group-id message-group-id))
+  "Send a message to a FIFO queue.
+
+   Options:
+   message-group-id - a tag that specifies the group that this message
+                      belongs to. Messages belonging to the same group
+                      are guaranteed FIFO
+   deduplication-id -  token used for deduplication of sent messages"
+  [sqs-config
+   queue-url
+   payload
+   {message-group-id :message-group-id
+    deduplication-id :deduplication-id
+    :as options}]
+  (send-message* sqs-config queue-url payload options))
 
 ;; Controls ;;;;;;;;;;;;;;;;;
 

--- a/src/sqs_utils/core.clj
+++ b/src/sqs_utils/core.clj
@@ -190,6 +190,7 @@
    {message-group-id :message-group-id
     deduplication-id :deduplication-id
     :as options}]
+  {:pre [message-group-id]}
   (send-message* sqs-config queue-url payload options))
 
 ;; Controls ;;;;;;;;;;;;;;;;;

--- a/test/sqs_utils/core_test.clj
+++ b/test/sqs_utils/core_test.clj
@@ -107,6 +107,15 @@
                                     (str endpoint "/queue/non-existing")
                                     {:testing 1}))))))
 
+(deftest send-fifo-message-test
+  (testing "Fail case, missing :message-group-id"
+    (is (thrown? java.lang.AssertionError
+                 (su/send-fifo-message
+                   (sqs-config)
+                   @test-queue-url
+                   {:testing 1}
+                   {})))))
+
 (deftest roundtrip-datetime-test
   (let [coll {:data [1 2 3]
               :timestamp (t/now)}


### PR DESCRIPTION
This is a breaking change to `send-fifo-message` that changes the fn definition. I considered keeping the old signature for backward compatibility but I didn't like the old signature anyway so we might as well change it now.