### PR TITLE
Allow max messages configuration

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject motiva/sqs-utils "0.4.0"
+(defproject motiva/sqs-utils "0.5.0"
   :description "Higher level SQS utilities for use in Motiva products"
   :url "https://github.com/Motiva-AI/sqs-utils"
   :license {:name "MIT License"


### PR DESCRIPTION
Fink-nottle and SQS in general allow configuration of the maximum number of messages which may be returned from a single poll. The defaults here are 10, and I think this may produce a bottleneck in the case of high throughput, low overhead message processing.

This change exposes the configuration of this value via a new `:maximum-messages` options key.