### PR TITLE
Performance improvements and configurability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: lein deps
+          command: lein -U deps
 
       - save_cache:
           key: v3-sqs-utils-{{ arch }}-{{ checksum "project.clj" }}

--- a/project.clj
+++ b/project.clj
@@ -1,12 +1,16 @@
-(defproject motiva/sqs-utils "0.5.0"
+(defproject motiva/sqs-utils "0.6.0-SNAPSHOT"
   :description "Higher level SQS utilities for use in Motiva products"
   :url "https://github.com/Motiva-AI/sqs-utils"
   :license {:name "MIT License"
             :url  "https://opensource.org/licenses/MIT"}
 
-  :dependencies [[org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.10.1-beta2"]
                  [org.clojure/core.async "0.4.490"]
                  [io.nervous/fink-nottle "0.4.7"]
+                 ;; Cognitect Labs' aws-api project
+                 ;; [com.cognitect.aws/api "0.8.289"]
+                 ;; [com.cognitect.aws/endpoints "1.1.11.526"]
+                 ;; [com.cognitect.aws/sqs "697.2.391.0"]
                  [org.clojure/tools.logging "0.4.1"]
                  [clj-time "0.15.1"]
                  [cheshire "5.8.1"]                     ;; json

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject motiva/sqs-utils "0.6.0-SNAPSHOT"
+(defproject motiva/sqs-utils "0.6.0"
   :description "Higher level SQS utilities for use in Motiva products"
   :url "https://github.com/Motiva-AI/sqs-utils"
   :license {:name "MIT License"

--- a/src/sqs_utils/impl.clj
+++ b/src/sqs_utils/impl.clj
@@ -1,0 +1,48 @@
+(ns sqs-utils.impl
+  (:require [fink-nottle.sqs.channeled :as sqs.channeled]
+            [fink-nottle.sqs.tagged :as sqs.tagged]
+            [fink-nottle.sqs :as sqs]
+            [sqs-utils.serde :as serde]
+            [cheshire.core :as json]
+            [clojure.core.async :as async :refer [<!!]]))
+
+;; auto ser/de transit messages
+
+(defmethod sqs.tagged/message-in  :transit [_ body]
+  (serde/transit-read body))
+(defmethod sqs.tagged/message-out :transit [_ body]
+  (serde/transit-write body))
+
+;; similarly json
+
+(defmethod sqs.tagged/message-in :json [_ body]
+  (json/parse-string body true))
+(defmethod sqs.tagged/message-out :json [_ body]
+  (json/generate-string body))
+
+;; basics
+
+(defn receive!
+  [sqs-config queue-url opts]
+  (let [opts (merge {:maximum 10 :wait-seconds 20} opts)]
+    (sqs.channeled/receive! sqs-config queue-url opts)))
+
+(defn processed!
+  [sqs-config queue-url message]
+  (sqs/processed! sqs-config queue-url message))
+
+(defn send-message!
+  [sqs-config queue-url payload {:keys [message-group-id
+                                        deduplication-id
+                                        format]
+                                 :or {format :transit}}]
+  (let [resp (<!! (sqs/send-message!
+                    sqs-config
+                    queue-url
+                    (cond-> {:body payload :fink-nottle/tag format}
+                      message-group-id (assoc :message-group-id (str message-group-id))
+                      deduplication-id (assoc :message-deduplication-id (str deduplication-id)))))]
+    ;; sqs/send-message! returns Exceptions into the channel
+    (if (instance? Exception resp)
+      (throw resp)
+      resp)))


### PR DESCRIPTION
This change moves fink-nottle interations into an `impl` namespace in anticipation of eventually changing the implementation to use `aws-api` from Cognitect. For now, however, the changes to configuration allowing the use of multiple concurrent long-polling consumers result in significant increases in throughput, so I want to get this into production ASAP.