### PR TITLE
Make it possible to explicitly configure a single consumer

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject motiva/sqs-utils "0.6.0"
+(defproject motiva/sqs-utils "0.7.0"
   :description "Higher level SQS utilities for use in Motiva products"
   :url "https://github.com/Motiva-AI/sqs-utils"
   :license {:name "MIT License"

--- a/src/sqs_utils/core.clj
+++ b/src/sqs_utils/core.clj
@@ -61,7 +61,7 @@
             visibility-timeout    60
             restart-delay-seconds 1
             maximum-messages      10
-            num-consumers         nil}
+            num-consumers         1}
      :as   opts}]
    (let [receive-to-chan #(impl/receive! sqs-config queue-url
                                          {:visibility-timeout visibility-timeout
@@ -238,7 +238,7 @@
             auto-delete         true
             visibility-timeout  60
             maximum-messages    10
-            num-consumers       nil}
+            num-consumers       1}
      :as   opts}]
    (log/infof "Starting receive loop for %s with num-handler-threads: %d, auto-delete: %s, visibility-timeout: %d"
               queue-url num-handler-threads auto-delete visibility-timeout)

--- a/src/sqs_utils/impl.clj
+++ b/src/sqs_utils/impl.clj
@@ -35,15 +35,16 @@
 
 (defn receive!
   [sqs-config queue-url opts & n]
-  (let [opts (merge {:maximum 10 :wait-seconds 20} opts)]
-    (if-let [n (first n)]
+  (let [opts (merge {:maximum 10 :wait-seconds 20} opts)
+        n (or (first n) 1)]
+    (if (= 1 n)
+      (sqs.channeled/receive! sqs-config queue-url opts)
       (multiplex
         (loop [chs [] n n]
           (if (= n 0)
             chs
             (let [ch (sqs.channeled/receive! sqs-config queue-url opts)]
-              (recur (conj chs ch) (dec n))))))
-      (sqs.channeled/receive! sqs-config queue-url opts))))
+              (recur (conj chs ch) (dec n)))))))))
 
 (defn processed!
   [sqs-config queue-url message]


### PR DESCRIPTION
Previously we inferred one consumer if `:num-consumers` is unset (i.e. `nil`), and an explicit setting of 1 would cause a pointless extra channel and go loop inside of `multiplex`. Now we treat `nil` and `1` the same.