### PR TITLE
Feature/long period deduplication

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject motiva/sqs-utils "0.9.0-SNAPSHOT"
+(defproject motiva/sqs-utils "0.9.0-rc-dedup"
   :description "Higher level SQS utilities for use in Motiva products"
   :url "https://github.com/Motiva-AI/sqs-utils"
   :license {:name "MIT License"

--- a/src/sqs_utils/core.clj
+++ b/src/sqs_utils/core.clj
@@ -251,6 +251,9 @@
             maximum-messages    10
             num-consumers       1}
      :as   opts}]
+   {:pre [(string? queue-url)
+          ;; deduplication-time-period should only be set for fifo queues
+          (or (not deduplication-time-period) (impl/fifo? queue-url))]}
    (log/infof "Starting receive loop for %s with num-handler-threads: %d, auto-delete: %s, visibility-timeout: %d"
               queue-url num-handler-threads auto-delete visibility-timeout)
    (let [receive-chan (chan)

--- a/src/sqs_utils/core.clj
+++ b/src/sqs_utils/core.clj
@@ -292,11 +292,11 @@
                      (and deduplication-time-period
                           (not auto-delete))
                      (do
-                       (swap! deduplication-cache #(cache/miss % message-deduplication-id true))
+                       (swap! deduplication-cache #(assoc % message-deduplication-id true))
                        (handler-fn message
                                    (fn []
                                      ;; evict dedup-cache when done-fn is called
-                                     (swap! deduplication-cache #(cache/evict % message-deduplication-id))
+                                     (swap! deduplication-cache #(dissoc % message-deduplication-id))
                                      (log/debugf "Evicting message-deduplication-id [%s] from cache."
                                                  message-deduplication-id)
                                      (done-fn))))
@@ -309,7 +309,7 @@
                      ;; Case 4.
                      (and deduplication-time-period
                           auto-delete)
-                     (do (swap! deduplication-cache #(cache/miss % message-deduplication-id true))
+                     (do (swap! deduplication-cache #(assoc % message-deduplication-id true))
                          (handler-fn message))
 
                      ;; Case 5.

--- a/src/sqs_utils/core.clj
+++ b/src/sqs_utils/core.clj
@@ -223,9 +223,18 @@
       visibility-timeout  - how long (in seconds) a message can go unacknowledged
                             before delivery is retried. (defaults: 60)
 
-      deduplication-time-period - how long (in seconds) are messages deduplicated
-                                  if a new message arrives while the previous one
-                                  is still processing.
+      deduplication-time-period - How long (in seconds) are messages deduplicated.
+                                  This is an internal implementation that goes
+                                  beyond the AWS 5-min window deduplication limit.
+                                  However, it is a simplistic in-memory implementation
+                                  that do not persist incoming deduplication-ids.
+                                  Moreover, there is a difference on how this works
+                                  depending on 'auto-delete' flag. If 'auto-delete'
+                                  is enabled, then this deduplication-time-period
+                                  is fixed. But if 'auto-delete' is disabled, then
+                                  the deduplication-id cache is cleared when a
+                                  message's done function is called. Lastly, this
+                                  can only be turned on for FIFO queues.
 
       maximum-messages    - the maximum number of messages to be delivered as
                             a result of a single poll of SQS.

--- a/src/sqs_utils/impl.clj
+++ b/src/sqs_utils/impl.clj
@@ -6,6 +6,9 @@
             [cheshire.core :as json]
             [clojure.core.async :refer [<!! <! >! go-loop chan]]))
 
+(defn fifo? [queue-url]
+  (boolean (re-seq #"fifo$" queue-url)))
+
 ;; auto ser/de transit messages
 
 (defmethod sqs.tagged/message-in  :transit [_ body]


### PR DESCRIPTION
This PR extends `handle-queue` with a `deduplication-time-period` option to support extended deduplication beyond AWS's 5-min limit. We achieve that with an internal TTL cache of incoming deduplication-ids.

I added integration test to ensure meta values are returned. And unit tests to ensure that the dedup logic works.